### PR TITLE
Require admin privileges on Windows

### DIFF
--- a/src-tauri/windows.manifest
+++ b/src-tauri/windows.manifest
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity version="1.0.0.0" processorArchitecture="*" name="com.wittg3n.cloudy" type="win32" />
+  <description>Cloudy desktop application</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
## Summary
- add a Windows manifest requesting administrator privileges when Cloudy launches

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ebd94eb4c8331812348e8390bcc39)